### PR TITLE
Features/additional repositories

### DIFF
--- a/src/XperienceCommunity.DataRepository/DependencyInjection.cs
+++ b/src/XperienceCommunity.DataRepository/DependencyInjection.cs
@@ -33,6 +33,8 @@ public static class DependencyInjection
 
         services.TryAddScoped(typeof(IPageRepository<>), typeof(PageTypeRepository<>));
 
+        services.TryAddScoped<IMediaFileRepository, MediaFileRepository>();
+
         return services;
     }
 }

--- a/src/XperienceCommunity.DataRepository/Interfaces/IMediaFileRepository.cs
+++ b/src/XperienceCommunity.DataRepository/Interfaces/IMediaFileRepository.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Immutable;
+
+using CMS.MediaLibrary;
+
+namespace XperienceCommunity.DataRepository.Interfaces;
+
+/// <summary>
+/// Interface for media file repository to handle media file operations.
+/// </summary>
+public interface IMediaFileRepository
+{
+    /// <summary>
+    /// Retrieves a list of media files based on the provided GUIDs.
+    /// </summary>
+    /// <param name="mediaFileGuids">The GUIDs of the media files to retrieve.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an immutable list of <see cref="MediaFileInfo"/>.</returns>
+    Task<ImmutableList<MediaFileInfo>> GetMediaFilesAsync(IEnumerable<Guid> mediaFileGuids,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves a list of media files based on the provided related items.
+    /// </summary>
+    /// <param name="items">The related items to retrieve media files from.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an immutable list of <see cref="MediaFileInfo"/>.</returns>
+    Task<ImmutableList<MediaFileInfo>> GetAssetsFromRelatedItemsAsync(IEnumerable<AssetRelatedItem> items,
+        CancellationToken cancellationToken = default);
+}

--- a/src/XperienceCommunity.DataRepository/MediaFileRepository.cs
+++ b/src/XperienceCommunity.DataRepository/MediaFileRepository.cs
@@ -11,13 +11,13 @@ namespace XperienceCommunity.DataRepository;
 
 public sealed class MediaFileRepository : IMediaFileRepository
 {
-    private readonly IProgressiveCache _cache;
-    private readonly int _cacheMinutes;
+    private readonly IProgressiveCache cache;
+    private readonly int cacheMinutes;
 
     public MediaFileRepository(IProgressiveCache cache, RepositoryOptions options)
     {
-        _cache = cache;
-        _cacheMinutes = options?.CacheMinutes ?? 10;
+        this.cache = cache;
+        cacheMinutes = options?.CacheMinutes ?? 10;
     }
 
     public async Task<ImmutableList<MediaFileInfo>> GetAssetsFromRelatedItemsAsync(IEnumerable<AssetRelatedItem> items,
@@ -30,7 +30,7 @@ public sealed class MediaFileRepository : IMediaFileRepository
             return [];
         }
 
-        return await _cache.LoadAsync(
+        return await cache.LoadAsync(
             async (cacheSettings, ct) =>
             {
                 var results = (await new ObjectQuery<MediaFileInfo>()
@@ -47,7 +47,7 @@ public sealed class MediaFileRepository : IMediaFileRepository
                 return results.ToImmutableList();
             },
             new CacheSettings(
-                cacheMinutes: _cacheMinutes,
+                cacheMinutes: cacheMinutes,
                 useSlidingExpiration: true,
                 cacheItemNameParts:
                 [
@@ -69,7 +69,7 @@ public sealed class MediaFileRepository : IMediaFileRepository
             return [];
         }
 
-        return await _cache.LoadAsync(
+        return await cache.LoadAsync(
             async (cacheSettings, ct) =>
             {
                 var results = (await new ObjectQuery<MediaFileInfo>()
@@ -86,7 +86,7 @@ public sealed class MediaFileRepository : IMediaFileRepository
                 return results.ToImmutableList();
             },
             new CacheSettings(
-                cacheMinutes: _cacheMinutes,
+                cacheMinutes: cacheMinutes,
                 useSlidingExpiration: true,
                 cacheItemNameParts:
                 [

--- a/src/XperienceCommunity.DataRepository/MediaFileRepository.cs
+++ b/src/XperienceCommunity.DataRepository/MediaFileRepository.cs
@@ -1,0 +1,100 @@
+﻿using System.Collections.Immutable;
+
+using CMS.DataEngine;
+using CMS.Helpers;
+using CMS.MediaLibrary;
+
+using XperienceCommunity.DataRepository.Interfaces;
+using XperienceCommunity.DataRepository.Models;
+
+namespace XperienceCommunity.DataRepository;
+
+public sealed class MediaFileRepository : IMediaFileRepository
+{
+    private readonly IProgressiveCache _cache;
+    private readonly int _cacheMinutes;
+
+    public MediaFileRepository(IProgressiveCache cache, RepositoryOptions options)
+    {
+        _cache = cache;
+        _cacheMinutes = options?.CacheMinutes ?? 10;
+    }
+
+    public async Task<ImmutableList<MediaFileInfo>> GetAssetsFromRelatedItemsAsync(IEnumerable<AssetRelatedItem> items,
+        CancellationToken cancellationToken = default)
+    {
+        var assetItems = items?.ToList() ?? [];
+
+        if (assetItems.Count == 0)
+        {
+            return [];
+        }
+
+        return await _cache.LoadAsync(
+            async (cacheSettings, ct) =>
+            {
+                var results = (await new ObjectQuery<MediaFileInfo>()
+                        .ForAssets(assetItems)
+                        .GetEnumerableTypedResultAsync(cancellationToken: ct))
+                    .ToList() ?? [];
+
+                string[] dependencyKeys = results
+                    .Select(result => $"mediafile|{result.FileGUID}")
+                    .ToArray();
+
+                cacheSettings.CacheDependency = CacheHelper.GetCacheDependency(dependencyKeys);
+
+                return results.ToImmutableList();
+            },
+            new CacheSettings(
+                cacheMinutes: _cacheMinutes,
+                useSlidingExpiration: true,
+                cacheItemNameParts:
+                [
+                    nameof(MediaFileRepository),
+                    nameof(GetAssetsFromRelatedItemsAsync),
+                    .. assetItems.OrderBy(item => item.Name).Select(item => item.Name) ?? [],
+                ]
+            ), cancellationToken
+        );
+    }
+
+    public async Task<ImmutableList<MediaFileInfo>> GetMediaFilesAsync(IEnumerable<Guid> mediaFileGuids,
+            CancellationToken cancellationToken = default)
+    {
+        var guidList = mediaFileGuids?.ToList() ?? [];
+
+        if (guidList.Count == 0)
+        {
+            return [];
+        }
+
+        return await _cache.LoadAsync(
+            async (cacheSettings, ct) =>
+            {
+                var results = (await new ObjectQuery<MediaFileInfo>()
+                        .WhereIn(nameof(MediaFileInfo.FileGUID), guidList)
+                        .GetEnumerableTypedResultAsync(cancellationToken: ct))
+                    ?.ToList() ?? [];
+
+                string[] dependencyKeys = guidList
+                    .Select(x => $"mediafile|{x}")
+                    .ToArray();
+
+                cacheSettings.CacheDependency = CacheHelper.GetCacheDependency(dependencyKeys);
+
+                return results.ToImmutableList();
+            },
+            new CacheSettings(
+                cacheMinutes: _cacheMinutes,
+                useSlidingExpiration: true,
+                cacheItemNameParts:
+                [
+                    nameof(MediaFileRepository),
+                    nameof(GetMediaFilesAsync),
+                    guidList.GetHashCode(),
+                ]
+            ), cancellationToken
+        );
+    }
+}


### PR DESCRIPTION
Renamed private fields `_cache` to `cache` and `_cacheMinutes` to `cacheMinutes` in `MediaFileRepository.cs` to follow a consistent naming convention. Updated constructor and method calls to reflect these changes.