### PR TITLE
Refactor repositories and add async media library fetch

### DIFF
--- a/src/XperienceCommunity.DataRepository/ContentTypeRepository.cs
+++ b/src/XperienceCommunity.DataRepository/ContentTypeRepository.cs
@@ -94,14 +94,6 @@ public sealed class ContentTypeRepository<TEntity>(
                 config.When(maxLinkedItems > 0, linkOptions => linkOptions.WithLinkedItems(maxLinkedItems)))
             .When(!string.IsNullOrEmpty(languageName), lang => lang.InLanguage(languageName));
 
-        var queryOptions = GetQueryExecutionOptions();
-
-        if (WebsiteChannelContext.IsPreview)
-        {
-            return await Executor.GetMappedResult<TEntity>(builder, queryOptions,
-                cancellationToken: cancellationToken);
-        }
-
         var result = await ExecuteContentQuery<TEntity>(builder,
             () => CacheDependencyHelper.CreateContentItemTypeCacheDependency([contentType]),
             cancellationToken, CachePrefix, nameof(GetAllAsync), contentType, maxLinkedItems);

--- a/src/XperienceCommunity.DataRepository/Interfaces/IMediaFileRepository.cs
+++ b/src/XperienceCommunity.DataRepository/Interfaces/IMediaFileRepository.cs
@@ -9,6 +9,16 @@ namespace XperienceCommunity.DataRepository.Interfaces;
 /// </summary>
 public interface IMediaFileRepository
 {
+
+    /// <summary>
+    /// Retrieves a media library by its identifier.
+    /// </summary>
+    /// <param name="mediaLibraryId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>A task that represent the asynchronous operation. The task result contains a <see cref="MediaLibraryInfo"/>.</returns>
+    Task<MediaLibraryInfo?> GetMediaLibraryByIdAsync(int mediaLibraryId,
+        CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Retrieves a list of media files based on the provided GUIDs.
     /// </summary>

--- a/src/XperienceCommunity.DataRepository/MediaFileRepository.cs
+++ b/src/XperienceCommunity.DataRepository/MediaFileRepository.cs
@@ -14,10 +14,21 @@ public sealed class MediaFileRepository : IMediaFileRepository
     private readonly IProgressiveCache cache;
     private readonly int cacheMinutes;
 
-    public MediaFileRepository(IProgressiveCache cache, RepositoryOptions options)
+    public MediaFileRepository(IProgressiveCache progressiveCache, RepositoryOptions options)
     {
-        this.cache = cache;
+        cache = progressiveCache ?? throw new ArgumentNullException(nameof(progressiveCache));
         cacheMinutes = options?.CacheMinutes ?? 10;
+    }
+
+    /// <inheritdoc />
+    public async Task<MediaLibraryInfo?> GetMediaLibraryByIdAsync(int mediaLibraryId,
+        CancellationToken cancellationToken = default)
+    {
+        var objectQuery = await new ObjectQuery<MediaLibraryInfo>()
+            .WhereEquals(nameof(MediaLibraryInfo.LibraryID), mediaLibraryId)
+            .GetEnumerableTypedResultAsync(cancellationToken: cancellationToken);
+
+        return objectQuery?.FirstOrDefault();
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Modified ContentTypeRepository to remove conditional execution and directly call ExecuteContentQuery. Updated IMediaFileRepository to include GetMediaLibraryByIdAsync method. Renamed constructor parameter in MediaFileRepository and implemented the new async method with null check for progressiveCache.