### PR TITLE
Expand CacheDependencyHelper with new methods and tests

### DIFF
--- a/src/XperienceCommunity.DataRepository/Helpers/CacheDependencyHelper.cs
+++ b/src/XperienceCommunity.DataRepository/Helpers/CacheDependencyHelper.cs
@@ -2,201 +2,200 @@
 using CMS.Helpers;
 using CMS.Websites;
 
-namespace XperienceCommunity.DataRepository.Helpers
+namespace XperienceCommunity.DataRepository.Helpers;
+
+/// <summary>
+/// Provides helper methods for creating cache dependencies for content and web page items.
+/// </summary>
+public static class CacheDependencyHelper
 {
     /// <summary>
-    /// Provides helper methods for creating cache dependencies for content and web page items.
+    /// Creates cache keys for web page items by their GUIDs.
     /// </summary>
-    public static class CacheDependencyHelper
+    /// <param name="itemGuids">The GUIDs of the web page items.</param>
+    /// <returns>An array of cache keys.</returns>
+    public static string[] CreateContentItemGUIDKeys(IEnumerable<Guid>? itemGuids) =>
+        itemGuids?.Select(x => CreateContentItemGUIDKey(x))?.ToArray() ?? [];
+
+    /// <summary>
+    /// Creates cache keys for web page items by their GUIDs.
+    /// </summary>
+    /// <param name="itemGuids">The GUIDs of the web page items.</param>
+    /// <returns>An array of cache keys.</returns>
+    public static string[] CreateWebPageItemGUIDKeys(IEnumerable<Guid>? itemGuids) =>
+        itemGuids?.Select(x => CreateWebPageItemGUIDKey(x))?.ToArray() ?? [];
+
+    /// <summary>
+    /// Creates a cache key for a web page item by its GUID.
+    /// </summary>
+    /// <param name="itemGuid">The GUID of the web page item.</param>
+    /// <returns>A cache key.</returns>
+    public static string CreateWebPageItemGUIDKey(Guid? itemGuid) => $"webpageitem|byguid|{itemGuid}";
+
+    /// <summary>
+    /// Creates a cache key for a web page item by its ID.
+    /// </summary>
+    /// <param name="itemId">The ID of the web page item.</param>
+    /// <returns>A cache key.</returns>
+    public static string CreateWebPageItemIdKey(int? itemId) => $"webpageitem|byid|{itemId}";
+
+    /// <summary>
+    /// Creates a cache key for a content item by its GUID.
+    /// </summary>
+    /// <param name="itemGuid">The GUID of the web page item.</param>
+    /// <returns>A cache key.</returns>
+    public static string CreateContentItemGUIDKey(Guid? itemGuid) => $"contentitem|byguid|{itemGuid}";
+
+    /// <summary>
+    /// Creates a cache key for a content item by its ID.
+    /// </summary>
+    /// <param name="itemId">The ID of the web page item.</param>
+    /// <returns>A cache key.</returns>
+    public static string CreateContentItemIdKey(int? itemId) => $"contentitem|byid|{itemId}";
+
+    /// <summary>
+    /// Creates cache keys for content items by their IDs.
+    /// </summary>
+    /// <param name="itemIdList">The IDs of the web page items.</param>
+    /// <returns>An array of cache keys.</returns>
+    public static string[] CreateContentItemIdKeys(IEnumerable<int>? itemIdList) =>
+        itemIdList?.Select(x => CreateContentItemIdKey(x))?.ToArray() ?? [];
+
+    /// <summary>
+    /// Creates cache keys for web page items by their IDs.
+    /// </summary>
+    /// <param name="itemIdList">The IDs of the web page items.</param>
+    /// <returns>An array of cache keys.</returns>
+    public static string[] CreateWebPageItemIdKeys(IEnumerable<int>? itemIdList) =>
+        itemIdList?.Select(x => CreateWebPageItemIdKey(x))?.ToArray() ?? [];
+
+    /// <summary>
+    /// Creates cache keys for web page items by content type and channel name.
+    /// </summary>
+    /// <param name="contentTypes">The content types.</param>
+    /// <param name="channelName">The channel name.</param>
+    /// <returns>An array of cache keys.</returns>
+    public static string[] CreateWebPageItemTypeKeys(IEnumerable<string>? contentTypes, string channelName) =>
+        contentTypes?.Select(x => $"webpageitem|bychannel|{channelName}|bycontenttype|{x}")?.ToArray() ?? [];
+
+    /// <summary>
+    /// Creates cache keys for content items by content type.
+    /// </summary>
+    /// <param name="contentTypes">The content types.</param>
+    /// <returns>An array of cache keys.</returns>
+    public static string[] CreateContentItemTypeKeys(IEnumerable<string>? contentTypes) =>
+        contentTypes?.Select(x => $"contentitem|bycontenttype|{x}")?.ToArray() ?? [];
+
+    /// <summary>
+    /// Creates cache keys for content items by their GUIDs.
+    /// </summary>
+    /// <typeparam name="T">The type of the content items.</typeparam>
+    /// <param name="items">The content items.</param>
+    /// <returns>An array of cache keys.</returns>
+    public static string[] CreateContentItemKeys<T>(IEnumerable<T>? items) where T : IContentItemFieldsSource =>
+        items?.Select(x => $"contentitem|byid|{x.SystemFields.ContentItemGUID}")?.ToArray() ?? [];
+
+    /// <summary>
+    /// Creates cache keys for web page items by their IDs.
+    /// </summary>
+    /// <typeparam name="T">The type of the web page items.</typeparam>
+    /// <param name="items">The web page items.</param>
+    /// <returns>An array of cache keys.</returns>
+    public static string[] CreateWebPageItemKeys<T>(IEnumerable<T>? items) where T : IWebPageFieldsSource =>
+        items?.Select(x => $"webpageitem|byid|{x.SystemFields.WebPageItemID}")?.ToArray() ?? [];
+
+    /// <summary>
+    /// Creates a cache dependency for the specified content items.
+    /// </summary>
+    /// <typeparam name="T">The type of the content items.</typeparam>
+    /// <param name="items">The content items.</param>
+    /// <returns>A cache dependency for the specified content items.</returns>
+    public static CMSCacheDependency CreateContentItemCacheDependency<T>(IEnumerable<T>? items)
+        where T : IContentItemFieldsSource
     {
-        /// <summary>
-        /// Creates cache keys for web page items by their GUIDs.
-        /// </summary>
-        /// <param name="itemGuids">The GUIDs of the web page items.</param>
-        /// <returns>An array of cache keys.</returns>
-        public static string[] CreateContentItemGUIDKeys(IEnumerable<Guid>? itemGuids) =>
-            itemGuids?.Select(x => CreateContentItemGUIDKey(x))?.ToArray() ?? [];
+        string[] contentItemKeys = CreateContentItemKeys(items);
 
-        /// <summary>
-        /// Creates cache keys for web page items by their GUIDs.
-        /// </summary>
-        /// <param name="itemGuids">The GUIDs of the web page items.</param>
-        /// <returns>An array of cache keys.</returns>
-        public static string[] CreateWebPageItemGUIDKeys(IEnumerable<Guid>? itemGuids) =>
-            itemGuids?.Select(x => CreateWebPageItemGUIDKey(x))?.ToArray() ?? [];
+        return CacheHelper.GetCacheDependency(contentItemKeys);
+    }
 
-        /// <summary>
-        /// Creates a cache key for a web page item by its GUID.
-        /// </summary>
-        /// <param name="itemGuid">The GUID of the web page item.</param>
-        /// <returns>A cache key.</returns>
-        public static string CreateWebPageItemGUIDKey(Guid? itemGuid) => $"webpageitem|byguid|{itemGuid}";
+    /// <summary>
+    /// Creates a cache dependency for the specified web page items.
+    /// </summary>
+    /// <typeparam name="T">The type of the web page items.</typeparam>
+    /// <param name="items">The web page items.</param>
+    /// <returns>A cache dependency for the specified web page items.</returns>
+    public static CMSCacheDependency CreateWebPageItemCacheDependency<T>(IEnumerable<T>? items)
+        where T : IWebPageFieldsSource
+    {
+        string[] webPageItemKeys = CreateWebPageItemKeys(items);
+        return CacheHelper.GetCacheDependency(webPageItemKeys);
+    }
 
-        /// <summary>
-        /// Creates a cache key for a web page item by its ID.
-        /// </summary>
-        /// <param name="itemId">The ID of the web page item.</param>
-        /// <returns>A cache key.</returns>
-        public static string CreateWebPageItemIdKey(int? itemId) => $"webpageitem|byid|{itemId}";
+    /// <summary>
+    /// Creates a cache dependency for web page items by content type and channel name.
+    /// </summary>
+    /// <param name="contentTypes">The content types.</param>
+    /// <param name="channelName">The channel name.</param>
+    /// <returns>A cache dependency for the specified web page items.</returns>
+    public static CMSCacheDependency CreateWebPageItemTypeCacheDependency(IEnumerable<string>? contentTypes,
+        string channelName)
+    {
+        string[] webPageItemTypeKeys = CreateWebPageItemTypeKeys(contentTypes, channelName);
+        return CacheHelper.GetCacheDependency(webPageItemTypeKeys);
+    }
 
-        /// <summary>
-        /// Creates a cache key for a content item by its GUID.
-        /// </summary>
-        /// <param name="itemGuid">The GUID of the web page item.</param>
-        /// <returns>A cache key.</returns>
-        public static string CreateContentItemGUIDKey(Guid? itemGuid) => $"contentitem|byguid|{itemGuid}";
+    /// <summary>
+    /// Creates a cache dependency for content items by content type.
+    /// </summary>
+    /// <param name="contentTypes">The content types.</param>
+    /// <returns>A cache dependency for the specified content items.</returns>
+    public static CMSCacheDependency CreateContentItemTypeCacheDependency(IEnumerable<string>? contentTypes)
+    {
+        string[] contentItemTypeKeys = CreateContentItemTypeKeys(contentTypes);
+        return CacheHelper.GetCacheDependency(contentItemTypeKeys);
+    }
 
-        /// <summary>
-        /// Creates a cache key for a content item by its ID.
-        /// </summary>
-        /// <param name="itemId">The ID of the web page item.</param>
-        /// <returns>A cache key.</returns>
-        public static string CreateContentItemIdKey(int? itemId) => $"contentitem|byid|{itemId}";
+    /// <summary>
+    /// Creates a cache dependency for web page items by their GUIDs.
+    /// </summary>
+    /// <param name="itemGuids">The GUIDs of the web page items.</param>
+    /// <returns>A cache dependency for the specified web page items.</returns>
+    public static CMSCacheDependency CreateWebPageItemGUIDCacheDependency(IEnumerable<Guid>? itemGuids)
+    {
+        string[] webPageItemGUIDKeys = CreateWebPageItemGUIDKeys(itemGuids);
+        return CacheHelper.GetCacheDependency(webPageItemGUIDKeys);
+    }
 
-        /// <summary>
-        /// Creates cache keys for content items by their IDs.
-        /// </summary>
-        /// <param name="itemIdList">The IDs of the web page items.</param>
-        /// <returns>An array of cache keys.</returns>
-        public static string[] CreateContentItemIdKeys(IEnumerable<int>? itemIdList) =>
-            itemIdList?.Select(x => CreateContentItemIdKey(x))?.ToArray() ?? [];
+    /// <summary>
+    /// Creates a cache dependency for web page items by their IDs.
+    /// </summary>
+    /// <param name="itemIdList"></param>
+    /// <returns></returns>
+    public static CMSCacheDependency CreateWebPageItemIDCacheDependency(IEnumerable<int>? itemIdList)
+    {
+        string[] webPageItemIdKeys = CreateWebPageItemIdKeys(itemIdList);
+        return CacheHelper.GetCacheDependency(webPageItemIdKeys);
+    }
 
-        /// <summary>
-        /// Creates cache keys for web page items by their IDs.
-        /// </summary>
-        /// <param name="itemIdList">The IDs of the web page items.</param>
-        /// <returns>An array of cache keys.</returns>
-        public static string[] CreateWebPageItemIdKeys(IEnumerable<int>? itemIdList) =>
-            itemIdList?.Select(x => CreateWebPageItemIdKey(x))?.ToArray() ?? [];
+    /// <summary>
+    /// Creates a cache dependency for content items by their GUIDs.
+    /// </summary>
+    /// <param name="itemGuids">The GUIDs of the web page items.</param>
+    /// <returns>A cache dependency for the specified web page items.</returns>
+    public static CMSCacheDependency CreateContentItemGUIDCacheDependency(IEnumerable<Guid>? itemGuids)
+    {
+        string[] webPageItemGUIDKeys = CreateContentItemGUIDKeys(itemGuids);
+        return CacheHelper.GetCacheDependency(webPageItemGUIDKeys);
+    }
 
-        /// <summary>
-        /// Creates cache keys for web page items by content type and channel name.
-        /// </summary>
-        /// <param name="contentTypes">The content types.</param>
-        /// <param name="channelName">The channel name.</param>
-        /// <returns>An array of cache keys.</returns>
-        public static string[] CreateWebPageItemTypeKeys(IEnumerable<string>? contentTypes, string channelName) =>
-            contentTypes?.Select(x => $"webpageitem|bychannel|{channelName}|bycontenttype|{x}")?.ToArray() ?? [];
-
-        /// <summary>
-        /// Creates cache keys for content items by content type.
-        /// </summary>
-        /// <param name="contentTypes">The content types.</param>
-        /// <returns>An array of cache keys.</returns>
-        public static string[] CreateContentItemTypeKeys(IEnumerable<string>? contentTypes) =>
-            contentTypes?.Select(x => $"contentitem|bycontenttype|{x}")?.ToArray() ?? [];
-
-        /// <summary>
-        /// Creates cache keys for content items by their GUIDs.
-        /// </summary>
-        /// <typeparam name="T">The type of the content items.</typeparam>
-        /// <param name="items">The content items.</param>
-        /// <returns>An array of cache keys.</returns>
-        public static string[] CreateContentItemKeys<T>(IEnumerable<T>? items) where T : IContentItemFieldsSource =>
-            items?.Select(x => $"contentitem|byid|{x.SystemFields.ContentItemGUID}")?.ToArray() ?? [];
-
-        /// <summary>
-        /// Creates cache keys for web page items by their IDs.
-        /// </summary>
-        /// <typeparam name="T">The type of the web page items.</typeparam>
-        /// <param name="items">The web page items.</param>
-        /// <returns>An array of cache keys.</returns>
-        public static string[] CreateWebPageItemKeys<T>(IEnumerable<T>? items) where T : IWebPageFieldsSource =>
-            items?.Select(x => $"webpageitem|byid|{x.SystemFields.WebPageItemID}")?.ToArray() ?? [];
-
-        /// <summary>
-        /// Creates a cache dependency for the specified content items.
-        /// </summary>
-        /// <typeparam name="T">The type of the content items.</typeparam>
-        /// <param name="items">The content items.</param>
-        /// <returns>A cache dependency for the specified content items.</returns>
-        public static CMSCacheDependency CreateContentItemCacheDependency<T>(IEnumerable<T>? items)
-            where T : IContentItemFieldsSource
-        {
-            string[] contentItemKeys = CreateContentItemKeys(items);
-
-            return CacheHelper.GetCacheDependency(contentItemKeys);
-        }
-
-        /// <summary>
-        /// Creates a cache dependency for the specified web page items.
-        /// </summary>
-        /// <typeparam name="T">The type of the web page items.</typeparam>
-        /// <param name="items">The web page items.</param>
-        /// <returns>A cache dependency for the specified web page items.</returns>
-        public static CMSCacheDependency CreateWebPageItemCacheDependency<T>(IEnumerable<T>? items)
-            where T : IWebPageFieldsSource
-        {
-            string[] webPageItemKeys = CreateWebPageItemKeys(items);
-            return CacheHelper.GetCacheDependency(webPageItemKeys);
-        }
-
-        /// <summary>
-        /// Creates a cache dependency for web page items by content type and channel name.
-        /// </summary>
-        /// <param name="contentTypes">The content types.</param>
-        /// <param name="channelName">The channel name.</param>
-        /// <returns>A cache dependency for the specified web page items.</returns>
-        public static CMSCacheDependency CreateWebPageItemTypeCacheDependency(IEnumerable<string>? contentTypes,
-            string channelName)
-        {
-            string[] webPageItemTypeKeys = CreateWebPageItemTypeKeys(contentTypes, channelName);
-            return CacheHelper.GetCacheDependency(webPageItemTypeKeys);
-        }
-
-        /// <summary>
-        /// Creates a cache dependency for content items by content type.
-        /// </summary>
-        /// <param name="contentTypes">The content types.</param>
-        /// <returns>A cache dependency for the specified content items.</returns>
-        public static CMSCacheDependency CreateContentItemTypeCacheDependency(IEnumerable<string>? contentTypes)
-        {
-            string[] contentItemTypeKeys = CreateContentItemTypeKeys(contentTypes);
-            return CacheHelper.GetCacheDependency(contentItemTypeKeys);
-        }
-
-        /// <summary>
-        /// Creates a cache dependency for web page items by their GUIDs.
-        /// </summary>
-        /// <param name="itemGuids">The GUIDs of the web page items.</param>
-        /// <returns>A cache dependency for the specified web page items.</returns>
-        public static CMSCacheDependency CreateWebPageItemGUIDCacheDependency(IEnumerable<Guid>? itemGuids)
-        {
-            string[] webPageItemGUIDKeys = CreateWebPageItemGUIDKeys(itemGuids);
-            return CacheHelper.GetCacheDependency(webPageItemGUIDKeys);
-        }
-
-        /// <summary>
-        /// Creates a cache dependency for web page items by their IDs.
-        /// </summary>
-        /// <param name="itemIdList"></param>
-        /// <returns></returns>
-        public static CMSCacheDependency CreateWebPageItemIDCacheDependency(IEnumerable<int>? itemIdList)
-        {
-            string[] webPageItemIdKeys = CreateWebPageItemIdKeys(itemIdList);
-            return CacheHelper.GetCacheDependency(webPageItemIdKeys);
-        }
-
-        /// <summary>
-        /// Creates a cache dependency for content items by their GUIDs.
-        /// </summary>
-        /// <param name="itemGuids">The GUIDs of the web page items.</param>
-        /// <returns>A cache dependency for the specified web page items.</returns>
-        public static CMSCacheDependency CreateContentItemGUIDCacheDependency(IEnumerable<Guid>? itemGuids)
-        {
-            string[] webPageItemGUIDKeys = CreateContentItemGUIDKeys(itemGuids);
-            return CacheHelper.GetCacheDependency(webPageItemGUIDKeys);
-        }
-
-        /// <summary>
-        /// Creates a cache dependency for content items by their IDs.
-        /// </summary>
-        /// <param name="itemIdList"></param>
-        /// <returns></returns>
-        public static CMSCacheDependency CreateContentItemIDCacheDependency(IEnumerable<int>? itemIdList)
-        {
-            string[] webPageItemIdKeys = CreateContentItemIdKeys(itemIdList);
-            return CacheHelper.GetCacheDependency(webPageItemIdKeys);
-        }
+    /// <summary>
+    /// Creates a cache dependency for content items by their IDs.
+    /// </summary>
+    /// <param name="itemIdList"></param>
+    /// <returns></returns>
+    public static CMSCacheDependency CreateContentItemIDCacheDependency(IEnumerable<int>? itemIdList)
+    {
+        string[] webPageItemIdKeys = CreateContentItemIdKeys(itemIdList);
+        return CacheHelper.GetCacheDependency(webPageItemIdKeys);
     }
 }

--- a/tests/XperienceCommunity.DataRepository.Tests/Extensions/IContentItemFieldsSourceExtensionsTests.cs
+++ b/tests/XperienceCommunity.DataRepository.Tests/Extensions/IContentItemFieldsSourceExtensionsTests.cs
@@ -168,7 +168,7 @@ namespace XperienceCommunity.DataRepository.Tests.Extensions
 
         public class TestContentItemFieldsSource : IContentItemFieldsSource
         {
-            public static string CONTENT_TYPE_NAME = "TestContentItemFieldsSource";
+            public const string CONTENT_TYPE_NAME = "TestContentItemFieldsSource";
             public ContentItemFields SystemFields => new ContentItemFields();
         }
     }

--- a/tests/XperienceCommunity.DataRepository.Tests/Extensions/IWebPageFieldsSourceExtensionsTests.cs
+++ b/tests/XperienceCommunity.DataRepository.Tests/Extensions/IWebPageFieldsSourceExtensionsTests.cs
@@ -11,7 +11,7 @@ public class IWebPageFieldsSourceExtensionsTests
 {
     public class TestWebPageFieldsSource : IWebPageFieldsSource
     {
-        public static string CONTENT_TYPE_NAME = "TestWebPageFieldsSource";
+        public const string CONTENT_TYPE_NAME = "TestWebPageFieldsSource";
         public WebPageFields SystemFields => new();
     }
 

--- a/tests/XperienceCommunity.DataRepository.Tests/Extensions/TypeExtensionsTests.cs
+++ b/tests/XperienceCommunity.DataRepository.Tests/Extensions/TypeExtensionsTests.cs
@@ -188,7 +188,7 @@ namespace XperienceCommunity.DataRepository.Tests.Extensions
             var result = source.GetRelatedWebPageGuids(x => x.RelatedItems);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(new[] { guid1, guid2 }));
+            Assert.That(result, Is.EquivalentTo([guid1, guid2]));
         }
 
         [Test]
@@ -302,7 +302,7 @@ namespace XperienceCommunity.DataRepository.Tests.Extensions
 
         public class TestContentItemFieldsSource : IContentItemFieldsSource
         {
-            public static string CONTENT_TYPE_NAME = "TestContentItemFieldsSource";
+            public const string CONTENT_TYPE_NAME = "TestContentItemFieldsSource";
 
             public AssetRelatedItem RelatedAssetItem { get; set; } = new AssetRelatedItem();
 
@@ -314,7 +314,7 @@ namespace XperienceCommunity.DataRepository.Tests.Extensions
 
         public class TestWebPageFieldsSource : IWebPageFieldsSource
         {
-            public static string CONTENT_TYPE_NAME = "TestWebPageFieldsSource";
+            public const string CONTENT_TYPE_NAME = "TestWebPageFieldsSource";
 
             public WebPageRelatedItem RelatedItem { get; set; } = new WebPageRelatedItem();
 

--- a/tests/XperienceCommunity.DataRepository.Tests/Helpers/CacheDependencyHelperTests.cs
+++ b/tests/XperienceCommunity.DataRepository.Tests/Helpers/CacheDependencyHelperTests.cs
@@ -1,0 +1,229 @@
+using CMS.ContentEngine;
+using CMS.Websites;
+
+using XperienceCommunity.DataRepository.Helpers;
+
+namespace XperienceCommunity.DataRepository.Tests.Helpers
+{
+    [TestFixture]
+    public class CacheDependencyHelperTests
+    {
+        [Test]
+        public void CreateContentItemGUIDKeys_ShouldReturnEmptyArray_WhenItemGuidsIsNull()
+        {
+            // Act
+            string[] result = CacheDependencyHelper.CreateContentItemGUIDKeys(null);
+
+            // Assert
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void CreateContentItemGUIDKeys_ShouldReturnCacheKeys_WhenItemGuidsIsNotNull()
+        {
+            // Arrange
+            var guids = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+
+            // Act
+            string[] result = CacheDependencyHelper.CreateContentItemGUIDKeys(guids);
+
+            // Assert
+            Assert.That(result.Length, Is.EqualTo(guids.Count));
+            Assert.That(result[0], Is.EqualTo($"contentitem|byguid|{guids[0]}"));
+            Assert.That(result[1], Is.EqualTo($"contentitem|byguid|{guids[1]}"));
+        }
+
+        [Test]
+        public void CreateWebPageItemGUIDKeys_ShouldReturnEmptyArray_WhenItemGuidsIsNull()
+        {
+            // Act
+            string[] result = CacheDependencyHelper.CreateWebPageItemGUIDKeys(null);
+
+            // Assert
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void CreateWebPageItemGUIDKeys_ShouldReturnCacheKeys_WhenItemGuidsIsNotNull()
+        {
+            // Arrange
+            var guids = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+
+            // Act
+            string[] result = CacheDependencyHelper.CreateWebPageItemGUIDKeys(guids);
+
+            // Assert
+            Assert.That(result.Length, Is.EqualTo(guids.Count));
+            Assert.That(result[0], Is.EqualTo($"webpageitem|byguid|{guids[0]}"));
+            Assert.That(result[1], Is.EqualTo($"webpageitem|byguid|{guids[1]}"));
+        }
+
+        [Test]
+        public void CreateContentItemIdKeys_ShouldReturnEmptyArray_WhenItemIdListIsNull()
+        {
+            // Act
+            string[] result = CacheDependencyHelper.CreateContentItemIdKeys(null);
+
+            // Assert
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void CreateContentItemIdKeys_ShouldReturnCacheKeys_WhenItemIdListIsNotNull()
+        {
+            // Arrange
+            var ids = new List<int> { 1, 2 };
+
+            // Act
+            string[] result = CacheDependencyHelper.CreateContentItemIdKeys(ids);
+
+            // Assert
+            Assert.That(result.Length, Is.EqualTo(ids.Count));
+            Assert.That(result[0], Is.EqualTo("contentitem|byid|1"));
+            Assert.That(result[1], Is.EqualTo("contentitem|byid|2"));
+        }
+
+        [Test]
+        public void CreateWebPageItemIdKeys_ShouldReturnEmptyArray_WhenItemIdListIsNull()
+        {
+            // Act
+            string[] result = CacheDependencyHelper.CreateWebPageItemIdKeys(null);
+
+            // Assert
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void CreateWebPageItemIdKeys_ShouldReturnCacheKeys_WhenItemIdListIsNotNull()
+        {
+            // Arrange
+            var ids = new List<int> { 1, 2 };
+
+            // Act
+            string[] result = CacheDependencyHelper.CreateWebPageItemIdKeys(ids);
+
+            // Assert
+            Assert.That(result.Length, Is.EqualTo(ids.Count));
+            Assert.That(result[0], Is.EqualTo("webpageitem|byid|1"));
+            Assert.That(result[1], Is.EqualTo("webpageitem|byid|2"));
+        }
+
+        [Test]
+        public void CreateWebPageItemTypeKeys_ShouldReturnEmptyArray_WhenContentTypesIsNull()
+        {
+            // Act
+            string[] result = CacheDependencyHelper.CreateWebPageItemTypeKeys(null, "channel");
+
+            // Assert
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void CreateWebPageItemTypeKeys_ShouldReturnCacheKeys_WhenContentTypesIsNotNull()
+        {
+            // Arrange
+            var contentTypes = new List<string> { "type1", "type2" };
+
+            // Act
+            string[] result = CacheDependencyHelper.CreateWebPageItemTypeKeys(contentTypes, "channel");
+
+            // Assert
+            Assert.That(result.Length, Is.EqualTo(contentTypes.Count));
+            Assert.That(result[0], Is.EqualTo("webpageitem|bychannel|channel|bycontenttype|type1"));
+            Assert.That(result[1], Is.EqualTo("webpageitem|bychannel|channel|bycontenttype|type2"));
+        }
+
+        [Test]
+        public void CreateContentItemTypeKeys_ShouldReturnEmptyArray_WhenContentTypesIsNull()
+        {
+            // Act
+            string[] result = CacheDependencyHelper.CreateContentItemTypeKeys(null);
+
+            // Assert
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void CreateContentItemTypeKeys_ShouldReturnCacheKeys_WhenContentTypesIsNotNull()
+        {
+            // Arrange
+            var contentTypes = new List<string> { "type1", "type2" };
+
+            // Act
+            string[] result = CacheDependencyHelper.CreateContentItemTypeKeys(contentTypes);
+
+            // Assert
+            Assert.That(result.Length, Is.EqualTo(contentTypes.Count));
+            Assert.That(result[0], Is.EqualTo("contentitem|bycontenttype|type1"));
+            Assert.That(result[1], Is.EqualTo("contentitem|bycontenttype|type2"));
+        }
+
+        [Test]
+        public void CreateContentItemKeys_ShouldReturnEmptyArray_WhenItemsIsNull()
+        {
+            // Act
+            string[] result = CacheDependencyHelper.CreateContentItemKeys<IContentItemFieldsSource>(null);
+
+            // Assert
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void CreateContentItemKeys_ShouldReturnCacheKeys_WhenItemsIsNotNull()
+        {
+            // Arrange
+            var items = new List<IContentItemFieldsSource>
+            {
+                new MockContentItemFieldsSource { SystemFields = new ContentItemFields { ContentItemGUID = Guid.NewGuid() } },
+                new MockContentItemFieldsSource { SystemFields = new ContentItemFields { ContentItemGUID = Guid.NewGuid() } }
+            };
+
+            // Act
+            string[] result = CacheDependencyHelper.CreateContentItemKeys(items);
+
+            // Assert
+            Assert.That(result.Length, Is.EqualTo(items.Count));
+            Assert.That(result[0], Is.EqualTo($"contentitem|byid|{items[0].SystemFields.ContentItemGUID}"));
+            Assert.That(result[1], Is.EqualTo($"contentitem|byid|{items[1].SystemFields.ContentItemGUID}"));
+        }
+
+        [Test]
+        public void CreateWebPageItemKeys_ShouldReturnEmptyArray_WhenItemsIsNull()
+        {
+            // Act
+            string[] result = CacheDependencyHelper.CreateWebPageItemKeys<IWebPageFieldsSource>(null);
+
+            // Assert
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void CreateWebPageItemKeys_ShouldReturnCacheKeys_WhenItemsIsNotNull()
+        {
+            // Arrange
+            var items = new List<IWebPageFieldsSource>
+            {
+                new MockWebPageFieldsSource { SystemFields = new WebPageFields { WebPageItemID = 1 } },
+                new MockWebPageFieldsSource { SystemFields = new WebPageFields { WebPageItemID = 2 } }
+            };
+
+            // Act
+            string[] result = CacheDependencyHelper.CreateWebPageItemKeys(items);
+
+            // Assert
+            Assert.That(result.Length, Is.EqualTo(items.Count));
+            Assert.That(result[0], Is.EqualTo("webpageitem|byid|1"));
+            Assert.That(result[1], Is.EqualTo("webpageitem|byid|2"));
+        }
+
+        public class MockContentItemFieldsSource : IContentItemFieldsSource
+        {
+            public ContentItemFields SystemFields { get; set; } = new ContentItemFields();
+        }
+
+        public class MockWebPageFieldsSource : IWebPageFieldsSource
+        {
+            public WebPageFields SystemFields { get; set; } = new WebPageFields();
+        }
+    }
+}


### PR DESCRIPTION
The `CacheDependencyHelper` class has been significantly expanded with new methods for creating cache keys and dependencies for content and web page items. Detailed XML documentation has been added for each method.

The `CONTENT_TYPE_NAME` field in `TestContentItemFieldsSource` and `TestWebPageFieldsSource` classes has been changed from `static` to `const` in multiple test files.

In `TypeExtensionsTests.cs`, the `Assert.That` method call has been updated to use square brackets for array initialization.

A new test class `CacheDependencyHelperTests` has been added, including various unit tests for the methods in `CacheDependencyHelper`, with mock implementations of `IContentItemFieldsSource` and `IWebPageFieldsSource` for testing purposes.